### PR TITLE
Add optional name field in channel's admin

### DIFF
--- a/socialfeedsparser/admin.py
+++ b/socialfeedsparser/admin.py
@@ -23,7 +23,7 @@ class ChannelAdmin(admin.ModelAdmin):
     """
     Admin class for the Channel model.
     """
-    list_display = ('query', 'source', 'query_type', 'updated', 'is_active')
+    list_display = ('query', 'name', 'source', 'query_type', 'updated', 'is_active')
     list_filter = ('query', 'source', 'query_type', 'updated', 'is_active')
     actions = [get_messages]
     radio_fields = {"query_type": admin.HORIZONTAL}

--- a/socialfeedsparser/migrations/0003_channel_name.py
+++ b/socialfeedsparser/migrations/0003_channel_name.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('socialfeedsparser', '0002_auto_20150701_0024'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channel',
+            name='name',
+            field=models.CharField(default=b'', max_length=100, verbose_name="Channel's name", blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/socialfeedsparser/models.py
+++ b/socialfeedsparser/models.py
@@ -43,7 +43,7 @@ class Channel(models.Model):
         verbose_name_plural = _('Social feed channels')
 
     def __unicode__(self):
-        return '%s - %s' % (self.get_source_display(), self.query)
+        return '%s - %s' % (self.get_source_display(), self.name or self.query)
 
     def can_update(self):
         """

--- a/socialfeedsparser/models.py
+++ b/socialfeedsparser/models.py
@@ -24,6 +24,7 @@ class Channel(models.Model):
         (SEARCH, _('search'))
     )
 
+    name = models.CharField(_('Channel\'s name'), max_length=100, blank=True, default='')
     source = models.CharField(_('Social media'), max_length=50, choices=SOURCE_CHOICES, default=SOURCE_CHOICES[0])
     limit = models.IntegerField(_('Limit'), null=True, blank=True)
     query = models.CharField(_('Query'), max_length=255, help_text=_('Enter a search query or user/page id.'))


### PR DESCRIPTION
This commit adds ability to name feed queries in Channel models admin. Can be useful for non-descriptive queries, for example consisting only of ID.
