### PR TITLE
Attempt to fix UnicodeDecodeError with unicode chars in query

### DIFF
--- a/socialfeedsparser/contrib/facebook/source.py
+++ b/socialfeedsparser/contrib/facebook/source.py
@@ -26,7 +26,7 @@ class FacebookSource(ChannelParser):
         :param count: number of items to retrieve (default 20).
         :type item: int
         """
-        return self.get_api().get_connections(feed_id, 'feed')['data']
+        return self.get_api().get_connections(feed_id.encode('utf-8'), 'feed')['data']
 
     def get_messages_search(self, search):
         """

--- a/socialfeedsparser/management/commands/collect_social_feeds.py
+++ b/socialfeedsparser/management/commands/collect_social_feeds.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         channels = Channel.objects.to_update()
         for channel in channels:
-            self.stdout.write('Processing source: "%s"' % channel)
+            self.stdout.write(u'Processing source: "%s"' % channel)
             sc = channel.source_class(channel=channel)
             sc.collect_messages()
             channel.updated = now()


### PR DESCRIPTION
This commit fixes some issues with unicode characters in Facebook feed_id. It makes sure that given feed_id is encoded in UTF-8 when it is passed to external fb library.
