### PR TITLE
Fixed linkedin message parser

### DIFF
--- a/socialfeedsparser/contrib/linkedin/source.py
+++ b/socialfeedsparser/contrib/linkedin/source.py
@@ -42,14 +42,17 @@ class LinkendInSource(ChannelParser):
 
     def prepare_message(self, message):
         """
-        Convert tweets to standard message.
+        Convert linkedin post to standard message.
 
         :param message: message entry to convert.
         :type item: dict
         """
-        share = message['updateContent']['companyStatusUpdate']['share']
-        l = 'https://www.linkedin.com/hp/updates?topic=%s' \
-            % message['updateKey'].split('-')[2]
+        try:
+            share = message['updateContent']['companyStatusUpdate']['share']
+            l = 'https://www.linkedin.com/hp/updates?topic=%s' % message['updateKey'].split('-')[2]
+        except KeyError:
+            raise
+
         return PostParser(
             uid=message['updateKey'].split('-')[2],
             author=message['updateContent']['company']['name'],

--- a/socialfeedsparser/contrib/parsers.py
+++ b/socialfeedsparser/contrib/parsers.py
@@ -28,9 +28,12 @@ class ChannelParser(object):
         Retrieves and saves message for the models.Channel instance.
         """
         messages = self.get_messages()
-        messages = [self.prepare_message(message) for message in messages]
         for message in messages:
-            message.save(channel=self.channel)
+            try:
+                parsed_message = self.prepare_message(message)
+            except KeyError:
+                continue
+            parsed_message.save(channel=self.channel)
 
     def get_messages(self):
         """


### PR DESCRIPTION
There was an issue when trying to parse the linkedin message. In some situations the 'companyStatusUpdate' field is not included in the parent field: 'updateContent' . With this fix we treat the 'keyerrror' exception and we skip the invalid message structure. We save only what we need.